### PR TITLE
Add PI_HOME and centralize Pi environment variables

### DIFF
--- a/dot_config/zsh/dot_zshenv
+++ b/dot_config/zsh/dot_zshenv
@@ -7,7 +7,8 @@ export SSH_AUTH_SOCK="$XDG_RUNTIME_DIR/ssh-agent.socket"
 
 export GPG_TTY=$(tty)
 
-export PI_CODING_AGENT_DIR=$HOME/.config/pi/agent
+export PI_HOME=$HOME/.config/pi
+export PI_CODING_AGENT_DIR=$PI_HOME/agent
 export PI_TELEMETRY=0
 export PI_SKIP_VERSION_CHECK=1
 

--- a/dot_zshenv
+++ b/dot_zshenv
@@ -1,6 +1,4 @@
 export ZDOTDIR=$HOME/.config/zsh
-export PI_CODING_AGENT_DIR=$HOME/.config/pi/agent
-
 if [[ -f "$ZDOTDIR/.zshenv" ]]; then
   source "$ZDOTDIR/.zshenv"
 fi


### PR DESCRIPTION
This change adds a new PI_HOME environment variable pointing to ~/.config/pi and updates PI_CODING_AGENT_DIR to use it. It also removes the redundant PI_CODING_AGENT_DIR definition from the root .zshenv to centralize configuration in .config/zsh/.zshenv.

---
*PR created automatically by Jules for task [14737249711420176295](https://jules.google.com/task/14737249711420176295) started by @egor-denysenko*