### PR TITLE
Add gh-work function to Zsh aliases

### DIFF
--- a/dot_config/zsh/aliases.zsh
+++ b/dot_config/zsh/aliases.zsh
@@ -1,3 +1,8 @@
+# Check for GH CLI availability
+if ! command -v gh &> /dev/null; then
+  echo "Warning: GitHub CLI (gh) is not installed."
+fi
+
 # Aliases
 alias l="ls -lah"
 
@@ -13,3 +18,24 @@ alias pdup='podman-compose up'
 if command -v rg &> /dev/null; then
   alias grep='rg'
 fi
+
+# Invoke a GH workflow from GH CLI
+gh-work() {
+  if [ "$#" -ne 3 ]; then
+    echo "Usage: gh-work <repo-link> <workflow-name> <jira-ticket>"
+    return 1
+  fi
+
+  local REPO=$1
+  local WORKFLOW=$2
+  local JIRA_TICKET=$3
+
+  # Ensure gh cli is installed
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "Error: GitHub CLI (gh) is not installed."
+    return 1
+  fi
+
+  echo "Triggering workflow '$WORKFLOW' in repository '$REPO' with JIRA ticket '$JIRA_TICKET'..."
+  gh workflow run "$WORKFLOW" --repo "$REPO" -f jira_ticket="$JIRA_TICKET"
+}


### PR DESCRIPTION
This PR adds a new Zsh function `gh-work` to the dotfiles' alias configuration. The function allows users to trigger a GitHub workflow by providing the repository link, workflow name, and a JIRA ticket as an input. It also introduces a check at the beginning of `aliases.zsh` to warn the user if the GitHub CLI (`gh`) is not installed on the system, as well as a check within the function itself for robust error handling.

---
*PR created automatically by Jules for task [12961668642712591453](https://jules.google.com/task/12961668642712591453) started by @egor-denysenko*