### PR TITLE
🧹 Remove duplicate NO_COLOR declaration in executable_betterGitBranch.sh

### DIFF
--- a/dot_config/scripts/executable_betterGitBranch.sh
+++ b/dot_config/scripts/executable_betterGitBranch.sh
@@ -6,7 +6,6 @@ GREEN='\033[0;32m'
 NO_COLOR='\033[0m'
 BLUE='\033[0;34m'
 YELLOW='\033[0;33m'
-NO_COLOR='\033[0m'
 
 width1=5
 width2=6


### PR DESCRIPTION
🎯 What: Removed duplicate NO_COLOR declaration in executable_betterGitBranch.sh.
💡 Why: Having a duplicate variable declaration reduces readability and can be confusing. Removing it improves code health.
✅ Verification: Ran the script directly, which functioned identically as expected. Checked syntax. Code review passed.
✨ Result: Cleaner code in `executable_betterGitBranch.sh`.

---
*PR created automatically by Jules for task [13086120470412715069](https://jules.google.com/task/13086120470412715069) started by @egor-denysenko*