### PR TITLE
🧹 [Code Health] Refactor formatting string to a single variable in `executable_betterGitBranch.sh`

### DIFF
--- a/dot_config/scripts/executable_betterGitBranch.sh
+++ b/dot_config/scripts/executable_betterGitBranch.sh
@@ -14,6 +14,8 @@ width3=30
 width4=20
 width5=40
 
+row_format="${GREEN}%-${width1}s ${RED}%-${width2}s ${BLUE}%-${width3}s ${YELLOW}%-${width4}s ${NO_COLOR}%-${width5}s\n"
+
 # Function to count commits
 count_commits() {
     local branch="$1"
@@ -27,10 +29,10 @@ count_commits() {
 # Main script
 main_branch=$(git rev-parse HEAD)
 
-printf "${GREEN}%-${width1}s ${RED}%-${width2}s ${BLUE}%-${width3}s ${YELLOW}%-${width4}s ${NO_COLOR}%-${width5}s\n" "Ahead" "Behind" "Branch" "Last Commit"  " "
+printf "$row_format" "Ahead" "Behind" "Branch" "Last Commit" " "
 
 # Separator line for clarity
-printf "${GREEN}%-${width1}s ${RED}%-${width2}s ${BLUE}%-${width3}s ${YELLOW}%-${width4}s ${NO_COLOR}%-${width5}s\n" "-----" "------" "------------------------------" "-------------------" " "
+printf "$row_format" "-----" "------" "------------------------------" "-------------------" " "
 
 
 format_string="%(objectname:short)@%(refname:short)@%(committerdate:relative)"
@@ -50,7 +52,7 @@ for branchdata in $(git for-each-ref --sort=-authordate --format="$format_string
             behind=$(echo "$ahead_behind" | cut -f1)
             
             # Display branch info
-	    printf "${GREEN}%-${width1}s ${RED}%-${width2}s ${BLUE}%-${width3}s ${YELLOW}%-${width4}s ${NO_COLOR}%-${width5}s\n" $ahead $behind $branch "$time" "$description"
+	    printf "$row_format" "$ahead" "$behind" "$branch" "$time" "$description"
     fi
 done
 


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Extracted a heavily repeated `printf` formatting string in `dot_config/scripts/executable_betterGitBranch.sh` into a constant variable named `row_format`. Also safely quoted all string variables passed into the `printf` call.

💡 **Why:** How this improves maintainability
Using a single variable drastically cleans up visual clutter, making the script easier to read. If column widths or colors need to be modified in the future, it can be updated in a single place instead of in three distinct locations. Quoting variables (`$ahead`, `$behind`, etc.) removes the risk of globbing and word splitting bugs, avoiding unexpected behaviors.

✅ **Verification:** How you confirmed the change is safe
Tested the script locally using bash to guarantee no regressions in behavior. The script executed correctly, and visual formatting matched exactly with the original version. Code review tool was also run and confirmed the correctness of the change.

✨ **Result:** The improvement achieved
A cleaner and safer bash script that prints the identical git branch info, adhering to DRY principles.

---
*PR created automatically by Jules for task [13112478496856539234](https://jules.google.com/task/13112478496856539234) started by @egor-denysenko*